### PR TITLE
Added DEFAULT case and auto-break to SWITCH for a nicer programming language

### DIFF
--- a/compiler/Lexer.java
+++ b/compiler/Lexer.java
@@ -99,6 +99,7 @@ public class Lexer {
         addKeywordMachine("CALL", compiler.TokenIntf.Type.CALL);
         addKeywordMachine("RETURN", compiler.TokenIntf.Type.RETURN);
         addKeywordMachine("BLOCK", compiler.TokenIntf.Type.BLOCK);
+        addKeywordMachine("DEFAULT", compiler.TokenIntf.Type.DEFAULT);
         
         compiler.StateMachineBase identifierMachine = new StateMachineIdentifier();
         addMachine(identifierMachine);

--- a/compiler/TokenIntf.java
+++ b/compiler/TokenIntf.java
@@ -50,6 +50,7 @@ public abstract class TokenIntf {
         CALL,
         RETURN,
         BLOCK,
+		DEFAULT,
 	}
 
 	public Type m_type;

--- a/compiler/ast/ASTCaseDefaultStmtNode.java
+++ b/compiler/ast/ASTCaseDefaultStmtNode.java
@@ -1,0 +1,33 @@
+package compiler.ast;
+
+import compiler.CompileEnv;
+import compiler.Instr;
+import compiler.InstrBlock;
+import compiler.InstrIntf;
+
+import java.io.OutputStreamWriter;
+
+public class ASTCaseDefaultStmtNode extends ASTCaseListElementStmtNode {
+    public ASTCaseDefaultStmtNode(ASTStmtNode blockStmt) {
+        super(blockStmt);
+    }
+
+    @Override
+    public void codegen(CompileEnv env, InstrIntf cond, InstrBlock switch_exit, int no) {
+        compiler.InstrBlock exec = env.createBlock("case_default_exec");
+        compiler.InstrBlock exit = env.createBlock("case_default_exit");
+
+        compiler.InstrIntf jmpIntoBlock = new compiler.Instr.JumpInstr(exec);
+        env.addInstr(jmpIntoBlock);
+
+        env.setCurrentBlock(exec);
+        blockStmt.codegen(env);
+    }
+
+    @Override
+    public void print(OutputStreamWriter outStream, String indent) throws Exception {
+        outStream.write(indent);
+        outStream.write("DEFAULT\n");
+        blockStmt.print(outStream, indent + "   ");
+    }
+}

--- a/compiler/ast/ASTCaseListElementStmtNode.java
+++ b/compiler/ast/ASTCaseListElementStmtNode.java
@@ -1,0 +1,23 @@
+package compiler.ast;
+
+import compiler.CompileEnv;
+import compiler.InstrIntf;
+
+public abstract class ASTCaseListElementStmtNode extends ASTStmtNode {
+    protected final ASTStmtNode blockStmt;
+
+    protected ASTCaseListElementStmtNode(ASTStmtNode blockStmt) {
+        this.blockStmt = blockStmt;
+    }
+
+    public abstract void codegen(CompileEnv env, InstrIntf cond, compiler.InstrBlock switch_exit, int no);
+
+    @Override
+    public void execute() {
+        blockStmt.execute();
+    }
+
+    public void execute(int value) {
+        this.execute();
+    }
+}

--- a/compiler/ast/ASTCaseStmtNode.java
+++ b/compiler/ast/ASTCaseStmtNode.java
@@ -4,12 +4,12 @@ import compiler.*;
 
 import java.io.OutputStreamWriter;
 
-public class ASTCaseStmtNode extends ASTStmtNode {
+public class ASTCaseStmtNode extends ASTCaseListElementStmtNode {
     private final Token caseLiteral;
-    private final ASTStmtNode blockStmt;
 
     public ASTCaseStmtNode(Token caseLiteral, ASTStmtNode blockStmt) {
-        this.caseLiteral = caseLiteral; this.blockStmt = blockStmt;
+        super(blockStmt);
+        this.caseLiteral = caseLiteral;
     }
 
     @Override
@@ -20,10 +20,6 @@ public class ASTCaseStmtNode extends ASTStmtNode {
     }
 
     @Override
-    public void execute() {
-        blockStmt.execute();
-    }
-
     public void codegen(CompileEnv env, InstrIntf cond, compiler.InstrBlock switch_exit, int no) {
         compiler.InstrBlock exec = env.createBlock("case_exec_" + no);
         compiler.InstrBlock check = env.createBlock("case_check_" + no);
@@ -49,6 +45,7 @@ public class ASTCaseStmtNode extends ASTStmtNode {
         env.setCurrentBlock(exit);
     }
 
+    @Override
     public void execute(int value) {
         var literal = Integer.parseInt(caseLiteral.m_value);
 

--- a/compiler/ast/ASTCaseStmtNode.java
+++ b/compiler/ast/ASTCaseStmtNode.java
@@ -24,7 +24,7 @@ public class ASTCaseStmtNode extends ASTStmtNode {
         blockStmt.execute();
     }
 
-    public void codegen(CompileEnv env, InstrIntf cond, int no) {
+    public void codegen(CompileEnv env, InstrIntf cond, compiler.InstrBlock switch_exit, int no) {
         compiler.InstrBlock exec = env.createBlock("case_exec_" + no);
         compiler.InstrBlock check = env.createBlock("case_check_" + no);
         compiler.InstrBlock exit = env.createBlock("case_exit_" + no);
@@ -43,7 +43,7 @@ public class ASTCaseStmtNode extends ASTStmtNode {
 
         env.setCurrentBlock(exec);
         blockStmt.codegen(env);
-        compiler.InstrIntf jmpToExit = new compiler.Instr.JumpInstr(exit);
+        compiler.InstrIntf jmpToExit = new compiler.Instr.JumpInstr(switch_exit);
         env.addInstr(jmpToExit);
 
         env.setCurrentBlock(exit);

--- a/compiler/ast/ASTCaselistStmtNode.java
+++ b/compiler/ast/ASTCaselistStmtNode.java
@@ -8,14 +8,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ASTCaselistStmtNode extends ASTStmtNode {
-    private final List<ASTCaseStmtNode> caseList = new ArrayList<>();
+    private final List<ASTCaseListElementStmtNode> caseList = new ArrayList<>();
     private final ASTExprNode expr;
 
     public ASTCaselistStmtNode(ASTExprNode expr) {
         this.expr = expr;
     }
 
-    public void addCase(ASTCaseStmtNode c) {
+    public void addCase(ASTCaseListElementStmtNode c) {
         caseList.add(c);
     }
 
@@ -30,7 +30,7 @@ public class ASTCaselistStmtNode extends ASTStmtNode {
     @Override
     public void execute() {
         var value = expr.eval();
-        for (ASTCaseStmtNode caseNode : caseList) {
+        for (ASTCaseListElementStmtNode caseNode : caseList) {
             caseNode.execute(value);
         }
     }
@@ -49,7 +49,7 @@ public class ASTCaselistStmtNode extends ASTStmtNode {
         var exprInstr = expr.getInstr();
 
         for (int i = 0; i <  caseList.size(); i++) {
-            ASTCaseStmtNode caseNode = caseList.get(i);
+            var caseNode = caseList.get(i);
             caseNode.codegen(env, exprInstr, exit, i);
 
         }

--- a/compiler/ast/ASTCaselistStmtNode.java
+++ b/compiler/ast/ASTCaselistStmtNode.java
@@ -50,7 +50,7 @@ public class ASTCaselistStmtNode extends ASTStmtNode {
 
         for (int i = 0; i <  caseList.size(); i++) {
             ASTCaseStmtNode caseNode = caseList.get(i);
-            caseNode.codegen(env, exprInstr, i);
+            caseNode.codegen(env, exprInstr, exit, i);
 
         }
 


### PR DESCRIPTION
group: Franziska Ommer, Leon Neumann, Dominik Ochs, Philipp Reichert

modified grammar:

```
switch: SWITCH LPAREN expression RPAREN LBRACE caselist RBRACE
caselist: case caselist
caselist: eps | default
default: DEFAULT COLON blockStmt
case: CASE literal COLON blockStmt
```

if present, DEFAULT case must be last case in switch. If it is not => syntax error. 

Here is an example program that showcases the new features: 

```
{
    // Expected output:
    // 0
    // 5

    // executes DEFAULT if no other cases match => prints 0
    SWITCH (6) {
        CASE 1: {
            PRINT 1;
        }
        CASE 2: {
            PRINT 2;
        }
        DEFAULT: {
            PRINT 0;
        }
    }

    // only executes first matching CASE 5 and doesn't execute DEFAULT since a match was found => prints only 5
    SWITCH (5) {
        CASE 10: {
            PRINT 10;
        }
        CASE 5: {
            PRINT 5;
        }
        CASE 5: {
            PRINT -1;
        }
        DEFAULT: {
            PRINT -2;
        }
    }

    // This would cause the following Compiler Exception:
    // Exception in thread main compiler.CompilerException: DEFAULT must be the last case in switch
    // at line X
    // CASE
    // Expected: RBRACE
    //SWITCH (100) {
    //   DEFAULT: {
    //       PRINT -100;
    //   }
    //   CASE: {
    //       PRINT -200;
    //   }
    //}
}
```